### PR TITLE
Check for syscall out of bound

### DIFF
--- a/kernel/arch/x86/sys/syscall.c
+++ b/kernel/arch/x86/sys/syscall.c
@@ -7,7 +7,7 @@
 
 void arch_syscall(struct x86_regs *r)
 {
-    if(r->eax > SYSCALL_COUNT)
+    if(r->eax >= syscall_cnt)
     {
 	printk("[%d:%d] %s: Not Defined Syscall\n", cur_thread->owner->pid, cur_thread->tid, cur_thread->owner->name);
 	arch_syscall_return(cur_thread,-ENOSYS);

--- a/kernel/arch/x86/sys/syscall.c
+++ b/kernel/arch/x86/sys/syscall.c
@@ -3,10 +3,17 @@
 #include <sys/proc.h>
 #include <sys/sched.h>
 #include <sys/syscall.h>
+#include <bits/errno.h>
 
 void arch_syscall(struct x86_regs *r)
 {
-    /* FIXME: Add some out-of-bounds checking code here */
+    if(r->eax > SYSCALL_COUNT)
+    {
+	printk("[%d:%d] %s: Not Defined Syscall\n", cur_thread->owner->pid, cur_thread->tid, cur_thread->owner->name);
+	arch_syscall_return(cur_thread,-ENOSYS);
+	return;
+    }
+	
     void (*syscall)() = syscall_table[r->eax];
     syscall(r->ebx, r->ecx, r->edx);
 }

--- a/kernel/include/sys/syscall.h
+++ b/kernel/include/sys/syscall.h
@@ -8,7 +8,6 @@
 #endif
 
 extern void (*syscall_table[])();
-
-#define SYSCALL_COUNT 37
+extern size_t syscall_cnt;
 
 #endif /* ! _SYSCALL_H */

--- a/kernel/include/sys/syscall.h
+++ b/kernel/include/sys/syscall.h
@@ -9,4 +9,6 @@
 
 extern void (*syscall_table[])();
 
+#define SYSCALL_COUNT 37
+
 #endif /* ! _SYSCALL_H */

--- a/kernel/include/sys/syscall.h
+++ b/kernel/include/sys/syscall.h
@@ -8,6 +8,6 @@
 #endif
 
 extern void (*syscall_table[])();
-extern size_t syscall_cnt;
+extern const size_t syscall_cnt;
 
 #endif /* ! _SYSCALL_H */

--- a/kernel/sys/syscall.c
+++ b/kernel/sys/syscall.c
@@ -719,4 +719,4 @@ void (*syscall_table[])() =  {
     /* 37 */    sys_getgid,
 };
 
-size_t syscall_cnt = sizeof(syscall_table)/sizeof(syscall_table[0]);
+size_t const syscall_cnt = sizeof(syscall_table)/sizeof(syscall_table[0]);

--- a/kernel/sys/syscall.c
+++ b/kernel/sys/syscall.c
@@ -718,3 +718,5 @@ void (*syscall_table[])() =  {
     /* 36 */    sys_getuid,
     /* 37 */    sys_getgid,
 };
+
+size_t syscall_cnt = sizeof(syscall_table)/sizeof(syscall_table[0]);


### PR DESCRIPTION
Added `SYSCALL_COUNT` Macro, to hold the current count of syscalls, which meant to be updated every time a syscall is added