### PR TITLE
Enhanced the script expirence, and added clean and dist clean

### DIFF
--- a/build-tools/build.sh
+++ b/build-tools/build.sh
@@ -2,7 +2,6 @@
 # Init
 #
 
-set -e #don't continue if a command return non zero
 mkdir -p sys
 mkdir -p libc/sysroot
 mkdir -p pkgs
@@ -10,88 +9,174 @@ top_dir=$(pwd)
 PERL_26=$(perl -e "if ($] gt '5.026000') { print 1 } else {print 0};")
 
 #
-# Cross binutils and GCC
+# PKGS
+#
+BINUTILS="binutils-2.28"
+GCC="gcc-7.3.0"
+AUTOCONF="autoconf-2.69"
+AUTOMAKE="automake-1.12.1"
+NEWLIB="newlib-3.0.0"
+
+pkgs_list=($BINUTILS $GCC  $AUTOCONF  $AUTOMAKE $NEWLIB);
+
+build_dirs=($BINUTILS $AUTOCONF $AUTOMAKE $NEWLIB "build-newlib" "build-gcc");
+
+#
+# clean
 #
 
-if [[ ! -f "pkgs/binutils-2.28.tar.gz" ]]; then
-	wget https://ftp.gnu.org/gnu/binutils/binutils-2.28.tar.gz;
-    mv "binutils-2.28.tar.gz" "pkgs/binutils-2.28.tar.gz";
-    rm -rf "binutils-2.28";
+if [ "$1" == "clean" ]
+then
+    echo "Okay I'll clean"
+    for d in "${build_dirs[@]}"
+    do
+	make clean -C $d;
+    done
+    echo "cleaned successfuly"
+    exit
 fi;
 
-if [[ ! -f "pkgs/gcc-7.3.0.tar.gz" ]]; then
-	wget https://ftp.gnu.org/gnu/gcc/gcc-7.3.0/gcc-7.3.0.tar.gz;
-    mv "gcc-7.3.0.tar.gz" "pkgs/gcc-7.3.0.tar.gz";
-    rm -rf "gcc-7.3.0";
+#
+# distclean
+#
+if [ "$1" == "distclean" ]
+   then
+       echo "Okay I'll remove everything"
+       for d in "${build_dirs[@]}"
+       do
+	   rm -rf $d;
+       done
+       #there are common folder in both list but for future change
+       for d in "${pkgs_list[@]}"
+       do
+	   rm -rf $d;
+       done
+       echo "Done.."
+       exit;
+fi
+
+
+
+set -e #don't continue if a command return non zero
+
+#
+#Download Packages
+#
+
+echo "Downloading Packages";
+
+if [[ ! -f "pkgs/$BINUTILS.tar.gz" ]]; then
+    wget -P pkgs https://ftp.gnu.org/gnu/binutils/binutils-2.28.tar.gz;
 fi;
 
-if [[ ! -d binutils-2.28 ]]; then
-	tar xzf "pkgs/binutils-2.28.tar.gz";
-    cd "binutils-2.28";
+if [[ ! -f "pkgs/$GCC.tar.gz" ]]; then
+    wget -P pkgs/ https://ftp.gnu.org/gnu/gcc/gcc-7.3.0/gcc-7.3.0.tar.gz;
+fi;
+
+if [[ ! -f "pkgs/$AUTOCONF.tar.gz" ]]; then
+    wget -P pkgs/ "https://ftp.gnu.org/gnu/autoconf/$AUTOCONF.tar.gz";
+fi;
+
+if [[ ! -f "pkgs/$AUTOMAKE.tar.gz" ]]; then
+    wget -P pkgs/ "https://ftp.gnu.org/gnu/automake/$AUTOMAKE.tar.gz";
+fi;
+
+if [[ ! -f "pkgs/$NEWLIB.tar.gz" ]]; then
+    wget -P pkgs/ "ftp://sourceware.org/pub/newlib/$NEWLIB.tar.gz";
+fi;
+
+echo "The packages are here now"
+
+#
+# Uncompressing
+#
+
+echo "Hey packages!, Make yourself home"
+echo "Uncompressing & Configuring.."
+
+
+if [[ ! -d $AUTOCONF ]]; then
+    tar xzf "pkgs/$AUTOCONF.tar.gz";
+    cd $AUTOCONF && ./configure --prefix=$top_dir/sys
+    cd ..
+fi
+
+if [[ ! -d $AUTOMAKE ]]; then
+    tar xzf "pkgs/$AUTOMAKE.tar.gz";
+    cd $AUTOMAKE;
+    if [ $PERL_26 -eq 1 ] #patch if version > 26
+    then
+	patch -N < ../patches/automake.patch
+    fi
+    ./configure --prefix=$top_dir/sys
+    cd ..
+fi
+
+if [[ ! -d $BINUTILS ]]; then
+    tar xzf "pkgs/$BINUTILS.tar.gz";
+    cd $BINUTILS
     ./configure --prefix=$top_dir/sys --target=i686-elf --disable-nls --disable-werror --with-sysroot;
-    make -j $(nproc) && make install;
-    cd ..;
-fi;
+    cd ..
+fi
 
-
-if [[ ! -d gcc-7.3.0 ]]; then
-	tar xzf "pkgs/gcc-7.3.0.tar.gz";
-    cd "gcc-7.3.0";
+if [[ ! -d "build-gcc" ]]; then
+    if [[ ! -d $GCC ]]; then
+	tar xzf "pkgs/$GCC.tar.gz";
+    fi;
+    cd "$GCC";
     ./contrib/download_prerequisites;
     cd ..;
     mkdir -p "build-gcc" && cd "build-gcc";
-    ../gcc-7.3.0/configure --prefix=$top_dir/sys --target=i686-elf --disable-nls --enable-languages=c,c++ --without-headers;
-    make -j $(nproc) all-gcc;
-    make -j $(nproc) all-target-libgcc;
-    make -j $(nproc) install-gcc;
-    make -j $(nproc) install-target-libgcc;
+    ../$GCC/configure --prefix=$top_dir/sys --target=i686-elf --disable-nls --enable-languages=c,c++ --without-headers;
     cd ..;
 fi;
+
+if [[ ! -d $NEWLIB ]]; then
+    tar xzf "pkgs/$NEWLIB.tar.gz";
+    cp aquila $NEWLIB/newlib/libc/sys/ -r;
+    cd $NEWLIB;
+    patch -p1 < ../patches/newlib.patch;
+    cd ..
+fi;
+
+echo "Everything is ready.."
 
 #
-#   autoconf and automake
+#Building
 #
 
-# Fetch autoconf and automake if not present
-if [[ ! -f "pkgs/autoconf-2.69.tar.gz" ]]; then
-    wget "https://ftp.gnu.org/gnu/autoconf/autoconf-2.69.tar.gz";
-    mv "autoconf-2.69.tar.gz" "pkgs/autoconf-2.69.tar.gz";
-    rm -rf "autoconf-2.69";
-	tar xzf "pkgs/autoconf-2.69.tar.gz";
-    cd autoconf-2.69 && ./configure --prefix=$top_dir/sys && make -j $(nproc) && make install;
-    cd ..;
-fi;
+echo "Let's start Building ...."
 
-if [[ ! -f "pkgs/automake-1.12.1.tar.gz" ]]; then
-    wget "https://ftp.gnu.org/gnu/automake/automake-1.12.1.tar.gz";
-    mv "automake-1.12.1.tar.gz" "pkgs/automake-1.12.1.tar.gz";
-    rm -rf "automake-1.12.1";
-    tar xzf "pkgs/automake-1.12.1.tar.gz";
-    cd automake-1.12.1;
-    
-    if [ $PERL_26 -eq 1 ] #patch if version > 26
-    then
-	patch < ../patches/automake.patch;
-    fi
-    
-    ./configure --prefix=$top_dir/sys && make -j $(nproc) && make install;
-    cd ..;
-fi;
+echo "Building binutils ...."
+cd $BINUTILS;
+make -j $(nproc) && make install;
+cd ..;
+echo "Done..."
 
-# newlib
-# Fetch & patch
-if [[ ! -f "pkgs/newlib-3.0.0.tar.gz" ]]; then
-    wget -O "pkgs/newlib-3.0.0.tar.gz" "ftp://sourceware.org/pub/newlib/newlib-3.0.0.tar.gz";
-fi;
+echo "Building gcc..."
+cd "build-gcc"
+make -j $(nproc) all-gcc;
+make -j $(nproc) all-target-libgcc;
+make -j $(nproc) install-gcc;
+make -j $(nproc) install-target-libgcc;
+cd ..;
+echo "Done.."
 
-# Always rebuild newlib
-rm -rf "newlib-3.0.0";
-tar -xzf "pkgs/newlib-3.0.0.tar.gz";
-cp aquila newlib-3.0.0/newlib/libc/sys/ -r;
-cd newlib-3.0.0;
-patch -p1 < ../patches/newlib.patch;
+echo "Building autoconf.."
+cd $AUTOCONF && make -j $(nproc) && make install;
+cd ..;
+echo "Done.."
+
+echo "Building automake.."
+cd $AUTOMAKE;
+make -j $(nproc) && make install;
+cd ..;
+echo "Done.."
+
+echo "Building newlib.."
+
+cd $NEWLIB;
 cd newlib/libc/sys/aquila;
-
 cd pthread; $top_dir/sys/bin/aclocal -I ../../../..;
 $top_dir/sys/bin/automake --cygnus Makefile;
 $top_dir/sys/bin/autoconf;
@@ -113,10 +198,11 @@ ln -f sys/bin/i686-elf-gcc sys/bin/i686-aquila-cc
 ln -f sys/bin/i686-elf-ranlib sys/bin/i686-aquila-ranlib
 export PATH=$top_dir/sys/bin:$PATH;
 rm -rf build-newlib && mkdir -p build-newlib && cd build-newlib;
-../newlib-3.0.0/configure --prefix=/usr --target=i686-aquila;
+../$NEWLIB/configure --prefix=/usr --target=i686-aquila;
 make -j $(nproc) CFLAGS=-march=i586 all;
 make DESTDIR=$top_dir/libc/sysroot install;
 cd ..;
 cp -ar $top_dir/libc/sysroot/usr/i686-aquila/* $top_dir/libc/sysroot/usr/
+echo "Done.."
 
 echo "The build was successful, you can now build the image"


### PR DESCRIPTION
separated uncompromising and configuring from building, for solving the rebuilding after an error problem, now it always build again, since make won't actually rebuild if everything is good,
clean: cleans the build binaries in each pkg (make clean)
distclean: removes all the build directories for clean installation