### PR TITLE
syscall pointer check

### DIFF
--- a/kernel/sys/syscall.c
+++ b/kernel/sys/syscall.c
@@ -365,6 +365,12 @@ static void sys_write(int fd, void *buf, size_t nbytes)
         return; 
     }
 
+    if(!proc_ptr_validate(cur_thread->owner,buf))
+    {
+	arch_syscall_return(cur_thread, -EFAULT);
+	return;
+    }
+    
     struct file *file = &cur_thread->owner->fds[fd];
     int ret = vfs_file_write(file, buf, nbytes);
     arch_syscall_return(cur_thread, ret);


### PR DESCRIPTION
is that the pointer check you want? *if yes I will add it to the rest*
is the entry and heap, hold the lower and upper limit of the vaddress of that process?
or we should check by iterating over vms?